### PR TITLE
fix(dicom-microscopy-viewer):Fix the units display

### DIFF
--- a/src/annotations/markups/_MarkupManager.js
+++ b/src/annotations/markups/_MarkupManager.js
@@ -254,10 +254,8 @@ class _MarkupManager {
             return;
           }
 
-          const view = this._map.getView()
-          const unitSuffix = getUnitSuffix(view)
           const format = this._getFormatter(feature)
-          const output = format(feature, unitSuffix, this._pyramid)
+          const output = format(feature, null, this._pyramid)
           this.update({
             feature,
             value: output,

--- a/src/annotations/markups/bidirectional/updateMarkup.js
+++ b/src/annotations/markups/bidirectional/updateMarkup.js
@@ -1,5 +1,5 @@
 import { getFeatureScoord3dLength } from "../../../scoord3dUtils.js";
-import { getUnitSuffix } from "../../../utils.js";
+import { getUnitSuffix, formatLength } from "../../../utils.js";
 
 const updateMarkup = (
   shortAxisFeature,
@@ -11,15 +11,15 @@ const updateMarkup = (
   const longAxisGeometry = longAxisFeature.getGeometry();
   const shortAxisLength = getFeatureScoord3dLength(shortAxisFeature, pyramid);
   const longAxisLength = getFeatureScoord3dLength(longAxisFeature, pyramid);
-  const L = `L ${longAxisLength.toFixed(2)} ${unitSuffix}`;
-  const W = ` W ${shortAxisLength.toFixed(2)} ${unitSuffix}`;
+  const L = `L ${formatLength(longAxisLength,unitSuffix)}`;
+  const W = ` W ${formatLength(shortAxisLength, unitSuffix)}`;
   const value = `${L}\n${W}`;
   markupManager.update({
     feature: longAxisFeature,
     value,
     coordinate: longAxisGeometry.getLastCoordinate(),
   });
-  longAxisFeature.setProperties({ shortAxisLength: shortAxisLength.toFixed(2) }, true);
+  longAxisFeature.setProperties({ shortAxisLength }, true);
 };
 
 export default updateMarkup;

--- a/src/annotations/markups/ellipse/updateMarkup.js
+++ b/src/annotations/markups/ellipse/updateMarkup.js
@@ -1,5 +1,5 @@
 import { getFeatureScoord3dArea } from "../../../scoord3dUtils";
-import { getUnitSuffix } from "../../../utils";
+import { formatArea } from "../../../utils";
 import { getEllipseId } from "./id";
 
 const updateMarkup = (
@@ -10,7 +10,6 @@ const updateMarkup = (
   const ellipseFeature = drawingSource.getFeatureById(ellipseFeatureId);
   if (ellipseFeature) {
     const view = map.getView();
-    const unitSuffix = getUnitSuffix(view);
     const ellipseGeometry = ellipseFeature.getGeometry();
     const area = getFeatureScoord3dArea(ellipseFeature, pyramid);
 
@@ -32,7 +31,7 @@ const updateMarkup = (
     const variance = sumSquared / count - mean * mean;
     const stdDev = Math.sqrt(variance);
 
-    const value1 = `Area: ${area.toFixed(2)} ${unitSuffix}`;
+    const value1 = `Area: ${formatArea(area)}`;
     const value2 = `Mean: ${mean.toFixed(2)} Std Dev:${stdDev.toFixed(2)}`;
     const value = `${value1}\n${value2}`;
     markupManager.update({

--- a/src/annotations/markups/measurement.js
+++ b/src/annotations/markups/measurement.js
@@ -1,5 +1,5 @@
 import Enums from "../../enums";
-import { getUnitSuffix } from "../../utils";
+import { formatArea, formatLength } from "../../utils";
 import {
   getFeatureScoord3dArea,
   getFeatureScoord3dLength,
@@ -9,18 +9,17 @@ import annotationInterface from "../annotationInterface";
 /**
  * Format measure output.
  *
- * @param {Feature} feature feature
- * @param {string} units units
+ * @param {Feature} feature feature, providing area in mm^2 or length in mm
+ * @param {string} units units - ignored
  * @return {string} The formatted measure of this feature
  */
 export const format = (feature, units, pyramid) => {
   const area = getFeatureScoord3dArea(feature, pyramid);
+  if( area ) return formatArea(area);
   const length = getFeatureScoord3dLength(feature, pyramid);
-  const value = length || area || 0;
-  return length
-    ? `${value.toFixed(2)} ${units}`
-    : `${value.toFixed(2)} ${units}²`;
-};
+  if( length ) return formatLength(length);
+  return '0';
+}
 
 /**
  * Checks if feature has measurement markup properties.
@@ -52,11 +51,10 @@ const MeasurementMarkup = (viewerProperties) => {
         }
 
         const view = map.getView();
-        const unitSuffix = getUnitSuffix(view);
         const ps = feature.get(Enums.InternalProperties.PresentationState);
         markupManager.create({
           feature,
-          value: format(feature, unitSuffix, pyramid),
+          value: format(feature, null, pyramid),
           position: ps && ps.markup ? ps.markup.coordinates : null,
         });
       }

--- a/src/scoord3dUtils.js
+++ b/src/scoord3dUtils.js
@@ -375,7 +375,7 @@ function getFeatureScoord3dLength (feature, pyramid) {
         let yLen = p2[1] - p1[1]
         xLen *= xLen
         yLen *= yLen
-        length += Math.sqrt(xLen + yLen) * 1000
+        length += Math.sqrt(xLen + yLen) 
       }
       return length
     } else {
@@ -407,7 +407,7 @@ function getFeatureScoord3dArea (feature, pyramid) {
       const scoord3dCoordinates = geometry
         .getCoordinates()[0]
         .map((c) => geometryCoordinates2scoord3dCoordinates(c, pyramid))
-      return areaOfPolygon(scoord3dCoordinates) * 1000
+      return areaOfPolygon(scoord3dCoordinates) 
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -387,6 +387,39 @@ function areNumbersAlmostEqual (a, b, eps = 1.e-6) {
   return Math.abs(a - b) < eps
 }
 
+
+const formatArea = area => {
+  let mult = 1;
+  let unit = 'mm';
+  if( area > 1000000 ) {
+    unit = 'm';
+    mult = 1/1000000;
+  } else if( area < 1 ) {
+    unit = 'μm';
+    mult = 1000000;
+  }
+  return `${(area*mult).toFixed(2)} ${unit}²`;
+}
+
+const formatLength = (length,unit) => {
+  let mult = 1;
+  if( unit=='km' || !unit && length > 1000000  ) {
+    unit = 'km';
+    mult = 1/1000000;
+  } else if( unit=='m' || !unit && length > 1000 ) {
+    unit = 'm';
+    mult = 1/1000;
+  } else if(  unit=='μm' || !unit && length < 1 ) {
+    unit = 'μm';
+    mult = 1000;
+  } else if( unit && unit!='mm' ) {
+    throw new Error(`Unknown length unit ${unit}`)
+  } else {
+    unit = 'mm';
+  }
+  return `${(length*mult).toFixed(2)} ${unit}`;
+}
+
 /**
  * Get view unit suffix.
  *
@@ -503,5 +536,7 @@ export {
   are2DArraysAlmostEqual,
   doContentItemsMatch,
   areCodedConceptsEqual,
-  getContentItemNameCodedConcept
+  getContentItemNameCodedConcept,
+  formatArea, 
+  formatLength,
 }


### PR DESCRIPTION
The units computation was previously disconnected from the formatting, meaning the value could be off by a 1000 or a million.  Take the desired units into account when formatting, and otherwise use the actual value to generate the correct units.