### PR TITLE
fix(annotations): Annotations styles hardening

### DIFF
--- a/src/annotations/markups/_MarkupManager.js
+++ b/src/annotations/markups/_MarkupManager.js
@@ -182,6 +182,8 @@ class _MarkupManager {
     position,
     isLinkable = true,
     isDraggable = true,
+    isUnclickable = true,
+    noOffset = false
   }) {
     const noMarkup = feature.get(
       Enums.InternalProperties.NoMarkup
@@ -196,29 +198,27 @@ class _MarkupManager {
       return
     }
 
-    if (this.has(id)) {
+    if (this.has(id)) { 
       console.warn('Markup for feature already exists', id)
       return this.get(id)
     }
 
-    const markup = { id, isLinkable, isDraggable, style }
+    const markup = { id, isLinkable, isDraggable, isUnclickable, noOffset, style }
 
     const element = document.createElement('div')
     element.id = markup.isDraggable ? Enums.InternalProperties.Markup : ''
     element.className = 'ol-tooltip ol-tooltip-measure'
     element.innerText = value
 
-    const spacedCoordinate = coordinateWithOffset(feature, DEFAULT_MARKUP_OFFSET, this._map)
-
-    element.onpointerdown = event => {
-      event.stopPropagation();
-    }
+    const spacedCoordinate = noOffset === true ? 
+      feature.getGeometry().getLastCoordinate() 
+      : coordinateWithOffset(feature, DEFAULT_MARKUP_OFFSET, this._map)
 
     markup.element = element
     markup.overlay = new Overlay({
       className: 'markup-container',
       positioning: 'center-center',
-      stopEvent: true,
+      stopEvent: isUnclickable,
       dragging: false,
       position: position || spacedCoordinate,
       element: markup.element,
@@ -444,7 +444,7 @@ class _MarkupManager {
 
     if (coordinate) {
       const padding = (markup.element.offsetWidth + markup.element.offsetHeight) / 2;
-      markup.overlay.setPosition(coordinateWithOffset(feature, DEFAULT_MARKUP_OFFSET + padding, this._map))
+      markup.overlay.setPosition(markup.noOffset === true ? coordinate : coordinateWithOffset(feature, DEFAULT_MARKUP_OFFSET + padding, this._map))
     }
 
     this._markups.set(id, markup)

--- a/src/annotations/markups/_MarkupManager.js
+++ b/src/annotations/markups/_MarkupManager.js
@@ -10,7 +10,6 @@ import Feature from 'ol/Feature'
 
 import Enums from '../../enums'
 import { getShortestLineBetweenOverlayAndFeature } from './utils'
-import { getUnitSuffix } from '../../utils'
 import { coordinateWithOffset } from '../../scoord3dUtils'
 import defaultStyles from '../styles'
 
@@ -184,6 +183,13 @@ class _MarkupManager {
     isLinkable = true,
     isDraggable = true,
   }) {
+    const noMarkup = feature.get(
+      Enums.InternalProperties.NoMarkup
+    );
+    if (noMarkup === true) {
+      return;
+    }
+            
     const id = feature.getId();
     if (!id) {
       console.warn('Failed to create markup, feature id not found')

--- a/src/annotations/markups/bidirectional/bidirectional.js
+++ b/src/annotations/markups/bidirectional/bidirectional.js
@@ -36,7 +36,7 @@ const isDrawingBidirectional = (drawingOptions) =>
   drawingOptions[Enums.InternalProperties.Bidirectional] === true;
 
 const attachChangeEvents = (longAxisFeature, viewerProperties) => {
-  const { drawingSource, map, drawingOptions } = viewerProperties;
+  const { drawingSource, map } = viewerProperties;
 
   longAxisFeature.setProperties({ isLongAxis: true }, true);
 
@@ -53,13 +53,7 @@ const attachChangeEvents = (longAxisFeature, viewerProperties) => {
       return;
     }
 
-    createAndAddShortAxisFeature(
-      longAxisFeature,
-      viewerProperties,
-      drawingOptions
-        ? getAxisStyle(drawingOptions[Enums.InternalProperties.StyleOptions])
-        : getAxisStyle()
-    );
+    createAndAddShortAxisFeature(longAxisFeature, viewerProperties);
   };
 
   const longAxisGeometry = longAxisFeature.getGeometry();
@@ -149,7 +143,9 @@ const onPointerDragHandler = (event) => {
 
   /** If clicking outside handles, just stop event and translate */
   if (isClickingAHandle === false) {
-    const { subFeatures } = draggedFeature.getProperties();
+    const subFeatures = draggedFeature.get(
+      Enums.InternalProperties.SubFeatures
+    );
     if (subFeatures && subFeatures.length > 0) {
       subFeatures.forEach((subFeature) => {
         const geometry = subFeature.getGeometry();
@@ -222,7 +218,7 @@ const bidirectional = Object.assign({}, annotationInterface, {
     /** TODO: Remove long axis check. */
     if (measurements && JSON.stringify(measurements).includes("Long Axis")) {
       attachChangeEvents(feature, viewerProperties);
-      createAndAddShortAxisFeature(feature, viewerProperties, getAxisStyle());
+      createAndAddShortAxisFeature(feature, viewerProperties);
       attachPointerEvents(viewerProperties);
     }
   },
@@ -384,14 +380,14 @@ const bidirectional = Object.assign({}, annotationInterface, {
       feature.setStyle(axisStyle);
       feature.set(Enums.InternalProperties.StyleOptions, styles);
 
-      const longAxisFeatureId = getLongAxisId(draggedFeature);
+      const longAxisFeatureId = getLongAxisId(feature);
       const longAxisFeature = drawingSource.getFeatureById(longAxisFeatureId);
       if (longAxisFeature) {
         longAxisFeature.setStyle(axisStyle);
         longAxisFeature.set(Enums.InternalProperties.StyleOptions, styles);
       }
     }
-  }
-})
+  },
+});
 
 export default bidirectional;

--- a/src/annotations/markups/bidirectional/createAndAddShortAxisFeature.js
+++ b/src/annotations/markups/bidirectional/createAndAddShortAxisFeature.js
@@ -6,11 +6,7 @@ import updateMarkup from "./updateMarkup";
 import { getShortAxisId } from "./id";
 import getShortAxisCoords from "./getShortAxisCoords";
 
-const createAndAddShortAxisFeature = (
-  longAxisFeature,
-  viewerProperties,
-  shortAxisStyle
-) => {
+const createAndAddShortAxisFeature = (longAxisFeature, viewerProperties) => {
   const { drawingSource } = viewerProperties;
   const id = getShortAxisId(longAxisFeature);
 
@@ -23,13 +19,17 @@ const createAndAddShortAxisFeature = (
     {
       isShortAxis: true,
       [Enums.InternalProperties.IsSilentFeature]: true,
-      subFeatures: [longAxisFeature]
+      [Enums.InternalProperties.SubFeatures]: [longAxisFeature],
     },
     true
   );
-  longAxisFeature.setProperties({ subFeatures: [feature] }, true);
-  feature.setStyle(shortAxisStyle);
+  longAxisFeature.setProperties(
+    { [Enums.InternalProperties.SubFeatures]: [feature] },
+    true
+  );
+  feature.setStyle(longAxisFeature.getStyle());
 
+  updateMarkup(feature, longAxisFeature, viewerProperties)
   feature.on(Enums.FeatureGeometryEvents.CHANGE, () =>
     updateMarkup(feature, longAxisFeature, viewerProperties)
   );

--- a/src/annotations/markups/ellipse/createAndAddEllipseFeature.js
+++ b/src/annotations/markups/ellipse/createAndAddEllipseFeature.js
@@ -42,7 +42,9 @@ const createAndAddEllipseFeature = (
 
   addFeature(ellipseFeature, viewerProperties);
 
-  updateMarkup(originalROIFeature, viewerProperties);
+  if (originalROIFeature) {
+    updateMarkup(originalROIFeature, viewerProperties);
+  }
 };
 
 export default createAndAddEllipseFeature;

--- a/src/annotations/markups/ellipse/createAndAddEllipseFeature.js
+++ b/src/annotations/markups/ellipse/createAndAddEllipseFeature.js
@@ -25,20 +25,24 @@ const createAndAddEllipseFeature = (
       isEllipseShape: true,
       [Enums.InternalProperties.IsSilentFeature]: true,
       [Enums.InternalProperties.ReadOnly]: true,
-      subFeatures: [ellipseHandlesFeature],
+      [Enums.InternalProperties.SubFeatures]: [ellipseHandlesFeature],
+    },
+    true
+  );
+  ellipseHandlesFeature.setProperties(
+    {
+      [Enums.InternalProperties.SubFeatures]: [ellipseFeature],
+      [Enums.InternalProperties.NoMarkup]: true 
     },
     true
   );
   ellipseFeature.setStyle(getEllipseStyle(ellipseFeature));
 
-  /** Remove markup from handles to add a new one to ellipse */
-  markupManager.remove(ellipseHandlesFeature.getId());
   markupManager.create({ feature: ellipseFeature, style: styles });
 
   addFeature(ellipseFeature, viewerProperties);
 
-  /** Add feature then update the markup */
-  updateMarkup(ellipseHandlesFeature, viewerProperties);
+  updateMarkup(originalROIFeature, viewerProperties);
 };
 
 export default createAndAddEllipseFeature;

--- a/src/annotations/markups/ellipse/createAndAddEllipseHandlesFeature.js
+++ b/src/annotations/markups/ellipse/createAndAddEllipseHandlesFeature.js
@@ -20,6 +20,8 @@ const createAndAddEllipseHandlesFeature = (
     {
       isEllipseHandles: true,
       [Enums.InternalProperties.CantBeTranslated]: true,
+      [Enums.InternalProperties.SubFeatures]: [ellipseROIFeature],
+      [Enums.InternalProperties.NoMarkup]: true 
     },
     true
   );

--- a/src/annotations/markups/ellipse/ellipse.js
+++ b/src/annotations/markups/ellipse/ellipse.js
@@ -124,7 +124,10 @@ const onPointerDragHandler = (event) => {
 };
 
 const attachChangeEvents = (ellipseHandlesFeature, viewerProperties) => {
-  ellipseHandlesFeature.setProperties({ isEllipseHandles: true }, true);
+  ellipseHandlesFeature.setProperties({ 
+    isEllipseHandles: true, 
+    [Enums.InternalProperties.NoMarkup]: true 
+  }, true);
 
   const ellipseHandlesGeometry = ellipseHandlesFeature.getGeometry();
 
@@ -230,7 +233,6 @@ const ellipse = Object.assign({}, annotationInterface, {
         ellipseHandlesFeatureId
       );
       if (ellipseHandlesFeature) {
-        markupManager.remove(feature.getId());
         removeFeature(ellipseHandlesFeature, viewerProperties);
       }
     }

--- a/src/annotations/markups/measurement.js
+++ b/src/annotations/markups/measurement.js
@@ -15,11 +15,11 @@ import annotationInterface from "../annotationInterface";
  */
 export const format = (feature, units, pyramid) => {
   const area = getFeatureScoord3dArea(feature, pyramid);
-  if( area ) return formatArea(area);
+  if (area) return formatArea(area);
   const length = getFeatureScoord3dLength(feature, pyramid);
-  if( length ) return formatLength(length);
-  return '0';
-}
+  if (length) return formatLength(length);
+  return "0";
+};
 
 /**
  * Checks if feature has measurement markup properties.
@@ -45,12 +45,6 @@ const MeasurementMarkup = (viewerProperties) => {
   return Object.assign({}, annotationInterface, {
     onAdd: (feature) => {
       if (_isMeasurement(feature)) {
-        const isSilentFeature = feature.get(Enums.InternalProperties.IsSilentFeature)
-        if (isSilentFeature == true) {
-          return;
-        }
-
-        const view = map.getView();
         const ps = feature.get(Enums.InternalProperties.PresentationState);
         markupManager.create({
           feature,

--- a/src/annotations/markups/textEvaluation.js
+++ b/src/annotations/markups/textEvaluation.js
@@ -75,6 +75,8 @@ const _onInteractionEventHandler = ({ feature, markupManager }) => {
     value: format(feature),
     isLinkable: featureHasMarker,
     isDraggable: featureHasMarker,
+    isUnclickable: false,
+    noOffset: true,
     position: ps && ps.markup ? ps.markup.coordinates : null,
   });
   _applyStyle(feature);

--- a/src/enums.js
+++ b/src/enums.js
@@ -11,7 +11,9 @@ export const InternalProperties = {
   ReadOnly: "isReadOnly",
   IsSilentFeature: "isSilent",
   CantBeTranslated: "cantBeTranslated",
-  VertexEnabled: "vertexEnabled"
+  VertexEnabled: "vertexEnabled",
+  NoMarkup: "noMarkup",
+  SubFeatures: "subFeatures"
 };
 
 export const Bidirectional = {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1504,7 +1504,6 @@ class VolumeImageViewer {
       /** Dont normalize when is annotation hook */
       this[_annotationManager].onAdd(e.feature)
 
-      console.debug('ROI ADDED', feature);
       publish(
         container,
         EVENT.ROI_ADDED,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1480,7 +1480,12 @@ class VolumeImageViewer {
       let feature = e.feature;
 
       /**
-       * Example: Silent until all features from a single annotation are done.
+       * A annotation might be composed of one or more features so
+       * after one feature is added in the drawing source does not mean that the 
+       * annotation is fully drawn. 
+       * 
+       * A silent feature is a feature that doesn't exist by itself and should not
+       * be considered inside any event handler.
        */
       const isSilentFeature = e.feature.get(Enums.InternalProperties.IsSilentFeature)
       if (isSilentFeature == true) {
@@ -1623,7 +1628,8 @@ class VolumeImageViewer {
         isEllipse: true,
         maxPoints: 1,
         minPoints: 1,
-        [Enums.InternalProperties.VertexEnabled]: false
+        [Enums.InternalProperties.VertexEnabled]: false,
+        [Enums.InternalProperties.NoMarkup]: true
       },
       box: {
         type: 'Circle',
@@ -1672,7 +1678,8 @@ class VolumeImageViewer {
       [Enums.InternalProperties.Markup]:
         options[Enums.InternalProperties.Markup],
       [Enums.InternalProperties.VertexEnabled]: options[Enums.InternalProperties.VertexEnabled],
-      [Enums.InternalProperties.Label]: options[Enums.InternalProperties.Label]
+      [Enums.InternalProperties.Label]: options[Enums.InternalProperties.Label],
+      [Enums.InternalProperties.NoMarkup]: geometryDrawOptions[Enums.InternalProperties.NoMarkup],
     }
     const drawOptions = Object.assign(
       internalDrawOptions,
@@ -1842,7 +1849,7 @@ class VolumeImageViewer {
     this[_interactions].translate.on(Enums.InteractionEvents.TRANSLATING, event => {
       const newCoordinate = event.coordinate;
       event.features.forEach(feature => {
-        const { subFeatures } = feature.getProperties();
+        const subFeatures = feature.get(Enums.InternalProperties.SubFeatures);
         if (subFeatures && subFeatures.length > 0) {
           subFeatures.forEach(subFeature => {
             const geometry = subFeature.getGeometry();
@@ -2345,6 +2352,10 @@ class VolumeImageViewer {
       const id = feature.getId()
       if (id === uid) {
         this.setFeatureStyle(feature, styleOptions)
+        const subFeatures = feature.get(Enums.InternalProperties.SubFeatures);
+        if (subFeatures && subFeatures.length > 0) {
+          subFeatures.forEach(feature => this.setFeatureStyle(feature, styleOptions));
+        }
         const isVisible = Object.keys(styleOptions).length !== 0
         this[_annotationManager].setMarkupVisibility(id, isVisible)
       }


### PR DESCRIPTION
- Fix active style for ellipse: when selecting annotation in the right panel the label was permanently set with active color.
- Fix bidirectional short axis style: when loading bidirectional from sr the short axis didn't have the same style as long axis.
- Fix ellipse multiple markup: before ellipse was displaying more than one measurement markup.